### PR TITLE
Stop '#' showing in address bar after first click.

### DIFF
--- a/src/jquery.quiccordion.js
+++ b/src/jquery.quiccordion.js
@@ -72,6 +72,7 @@
                       });
                       _openItems($(this).children('ul'));
                     }
+                    return false; // No more '#' in address bar
                 });
                //if it's in the active tree don't hide it
                if($(this).find(options.activeClass).length == 0 && depth > options.openLevel)


### PR DESCRIPTION
Added a "return false" to stop propagation of the click event, so that the address in the address bar won't change after the first click, postpending a '#'.
